### PR TITLE
darwin-rebuild: use `nix build --json` for flakes

### DIFF
--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -135,8 +135,12 @@ if [ -n "$flake" ]; then
     flake=$(nix "${flakeFlags[@]}" flake "$cmd" --json "${extraBuildFlags[@]}" "${extraLockFlags[@]}" -- "$flake" | jq -r .url)
 fi
 
-if [ "$action" != build ] && [ -z "$flake" ]; then
-  extraBuildFlags+=("--no-out-link")
+if [ "$action" != build ]; then
+  if [ -n "$flake" ]; then
+    extraBuildFlags+=("--no-link")
+  else
+    extraBuildFlags+=("--no-out-link")
+  fi
 fi
 
 if [ "$action" = edit ]; then

--- a/pkgs/nix-tools/darwin-rebuild.sh
+++ b/pkgs/nix-tools/darwin-rebuild.sh
@@ -153,8 +153,10 @@ if [ "$action" = switch ] || [ "$action" = build ] || [ "$action" = check ]; the
   if [ -z "$flake" ]; then
     systemConfig="$(nix-build '<darwin>' "${extraBuildFlags[@]}" -A system)"
   else
-    nix "${flakeFlags[@]}" build "$flake#$flakeAttr.system" "${extraBuildFlags[@]}" "${extraLockFlags[@]}"
-    systemConfig=$(readlink -f result)
+    systemConfig=$(nix "${flakeFlags[@]}" build --json \
+      "${extraBuildFlags[@]}" "${extraLockFlags[@]}" \
+      -- "$flake#$flakeAttr.system" \
+      | jq -r '.[0].outputs.out')
   fi
 fi
 


### PR DESCRIPTION
This avoids the need for the `result` symlink (which also allows us to
use `--no-link` for `darwin-rebuild (switch|check)`).